### PR TITLE
complain if potonly and project options are used together

### DIFF
--- a/limepy/limepy.py
+++ b/limepy/limepy.py
@@ -256,7 +256,10 @@ class limepy:
                ('Mj' not in kwargs and 'mj' in kwargs):
                 raise ValueError("Error: Supply both mj and Mj")
         self.raj = numpy.array([self.ra])
-
+        
+        if self.potonly and self.project:
+            raise ValueError('Error: You must not use potonly option when projection is required')
+        
         return
 
     def _logcheck(self, t, y):


### PR DESCRIPTION
Currently limepy throws an error if potonly and project options are used together.
The patch provides protection against it.

```
king = limepy.limepy(4, g=1, project=True, potonly=True)
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-12-814d91b7f792> in <module>()
----> 1 king = limepy.limepy(4, g=1, project=True, potonly=True)

/home/koposov/my_usr/pylib/lib/python2.7/site-packages/limepy/limepy.pyc in __init__(self, phi0, g, **kwargs)
    188 
    189         # Optional computation of model properties in projection
--> 190         if (self.project): self._project()
    191 
    192         # Optional output

/home/koposov/my_usr/pylib/lib/python2.7/site-packages/limepy/limepy.pyc in _project(self)
    728             z = sqrt(abs(r**2 - R[i]**2)) # avoid small neg. values
    729 
--> 730             Sigma[i] = 2.0*simps(self.rho[c], x=z)
    731             betaterm1 = 1 if i==0 else 1-self.beta[c]*R[i]**2/self.r[c]**2
    732             betaterm2 = 1 if i==0 else 1-self.beta[c]*(1-R[i]**2/self.r[c]**2)

AttributeError: limepy instance has no attribute 'rho'
```
