### PR TITLE
Include missing files in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include *.rst


### PR DESCRIPTION
Include missing files in sdist for #9

Tested with

```
++ mktemp -d
+ D=/tmp/tmp.uCbRGtFBgC
+ trap 'rm -rf /tmp/tmp.uCbRGtFBgC' EXIT
+ python -m venv /tmp/tmp.uCbRGtFBgC
+ python setup.py sdist -d /tmp/tmp.uCbRGtFBgC
running sdist
running egg_info
writing astro_limepy.egg-info/PKG-INFO
writing dependency_links to astro_limepy.egg-info/dependency_links.txt
writing requirements to astro_limepy.egg-info/requires.txt
writing top-level names to astro_limepy.egg-info/top_level.txt
reading manifest file 'astro_limepy.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'astro_limepy.egg-info/SOURCES.txt'
running check
creating astro-limepy-0.1.1
creating astro-limepy-0.1.1/astro_limepy.egg-info
creating astro-limepy-0.1.1/limepy
copying files to astro-limepy-0.1.1...
copying AUTHORS.rst -> astro-limepy-0.1.1
copying CONTRIBUTING.rst -> astro-limepy-0.1.1
copying HISTORY.rst -> astro-limepy-0.1.1
copying MANIFEST.in -> astro-limepy-0.1.1
copying README.rst -> astro-limepy-0.1.1
copying setup.cfg -> astro-limepy-0.1.1
copying setup.py -> astro-limepy-0.1.1
copying astro_limepy.egg-info/PKG-INFO -> astro-limepy-0.1.1/astro_limepy.egg-info
copying astro_limepy.egg-info/SOURCES.txt -> astro-limepy-0.1.1/astro_limepy.egg-info
copying astro_limepy.egg-info/dependency_links.txt -> astro-limepy-0.1.1/astro_limepy.egg-info
copying astro_limepy.egg-info/not-zip-safe -> astro-limepy-0.1.1/astro_limepy.egg-info
copying astro_limepy.egg-info/requires.txt -> astro-limepy-0.1.1/astro_limepy.egg-info
copying astro_limepy.egg-info/top_level.txt -> astro-limepy-0.1.1/astro_limepy.egg-info
copying limepy/__init__.py -> astro-limepy-0.1.1/limepy
copying limepy/limepy.py -> astro-limepy-0.1.1/limepy
copying limepy/sample.py -> astro-limepy-0.1.1/limepy
copying limepy/spes.py -> astro-limepy-0.1.1/limepy
Writing astro-limepy-0.1.1/setup.cfg
Creating tar archive
removing 'astro-limepy-0.1.1' (and everything under it)
+ cd /
+ /tmp/tmp.uCbRGtFBgC/bin/pip install /tmp/tmp.uCbRGtFBgC/astro-limepy-0.1.1.tar.gz
Processing /tmp/tmp.uCbRGtFBgC/astro-limepy-0.1.1.tar.gz
Collecting numpy (from astro-limepy==0.1.1)
  Using cached https://files.pythonhosted.org/packages/cf/5d/e8198f11dd73a91f7bde15ca88a2b78913fa2b416ae2dc2a6aeafcf4c63d/numpy-1.18.4-cp38-cp38-manylinux1_x86_64.whl
Collecting scipy>=0.14.0 (from astro-limepy==0.1.1)
  Using cached https://files.pythonhosted.org/packages/f3/08/8bdcdcd149ea41b655956feb7c19ebf7e1f561738bd5570b6ae015daf411/scipy-1.4.1-cp38-cp38-manylinux1_x86_64.whl
Installing collected packages: numpy, scipy, astro-limepy
  Running setup.py install for astro-limepy: started
    Running setup.py install for astro-limepy: finished with status 'done'
Successfully installed astro-limepy-0.1.1 numpy-1.18.4 scipy-1.4.1
WARNING: You are using pip version 19.2.3, however version 20.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
+ echo Success
Success
++ rm -rf /tmp/tmp.uCbRGtFBgC
```
